### PR TITLE
Sync: merge releases 2.2.3 and 2.2.4 from ncbo

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['3.0', '3.1']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'faraday-follow_redirects', '~> 0.3'
 gem 'pry'
 gem 'rake'
 gem 'rubocop', '~> 1.43'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gemspec
 gem 'pry'
 gem 'rake'
 gem 'rubocop', '~> 1.43'
-gem 'test-unit'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
 
 gem 'faraday-follow_redirects', '~> 0.3'
+gem 'pry'
 gem 'rake'
 gem 'rubocop', '~> 1.43'
-gem 'pry'
 gem 'test-unit'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'faraday-follow_redirects', '~> 0.3'
 gem 'rake'
 gem 'rubocop', '~> 1.43'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.2.3)
+    ontologies_api_client (2.2.4)
       activesupport (= 6.1.7.3)
       addressable (~> 2.8)
       excon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.2.2)
+    ontologies_api_client (2.2.3)
       activesupport (= 6.1.7.3)
       addressable (~> 2.8)
       excon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    power_assert (2.0.3)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -75,8 +74,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     spawnling (2.1.5)
-    test-unit (3.5.7)
-      power_assert
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -90,11 +87,11 @@ PLATFORMS
 
 DEPENDENCIES
   faraday-follow_redirects (~> 0.3)
+  minitest (~> 5.18)
   ontologies_api_client!
   pry
   rake
   rubocop (~> 1.43)
-  test-unit
 
 BUNDLED WITH
    2.3.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
     faraday-excon (2.1.0)
       excon (>= 0.27.4)
       faraday (~> 2.0)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
@@ -87,6 +89,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  faraday-follow_redirects (~> 0.3)
   ontologies_api_client!
   pry
   rake

--- a/config/config.test.rb
+++ b/config/config.test.rb
@@ -11,6 +11,7 @@ LinkedData::Client.config do |config|
   config.apikey      = ENV['UT_APIKEY']
   # config.apikey    = 'xxxxx-xxxxx-xxxxxxxxxx'
   config.links_attr  = 'links'
+  config.purl_host   = 'purl.bioontology.org'
   config.purl_prefix = 'https://purl.bioontology.org/ontology'
   config.cache       = false
 end

--- a/config/config.test.rb
+++ b/config/config.test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # config.rb is required for testing
 # unit test makes calls to bioportal api so it needs a valid API key which can
 # be set via ENV variable UT_APIKEY
@@ -5,10 +7,10 @@ abort('UT_APIKEY env variable is not set. Canceling tests') unless ENV.include?(
 abort('UT_APIKEY env variable is set to an empty value. Canceling tests') unless ENV['UT_APIKEY'].size > 5
 
 LinkedData::Client.config do |config|
-  config.rest_url   = 'https://data.bioontology.org'
-  config.apikey     = ENV['UT_APIKEY']
-#  config.apikey     = 'xxxxx-xxxxx-xxxxxxxxxx'
-  config.links_attr = 'links'
+  config.rest_url    = 'https://data.bioontology.org'
+  config.apikey      = ENV['UT_APIKEY']
+  # config.apikey    = 'xxxxx-xxxxx-xxxxxxxxxx'
+  config.links_attr  = 'links'
   config.purl_prefix = 'https://purl.bioontology.org/ontology'
-  config.cache      = false
+  config.cache       = false
 end

--- a/config/config.test.rb
+++ b/config/config.test.rb
@@ -9,5 +9,6 @@ LinkedData::Client.config do |config|
   config.apikey     = ENV['UT_APIKEY']
 #  config.apikey     = 'xxxxx-xxxxx-xxxxxxxxxx'
   config.links_attr = 'links'
+  config.purl_prefix = 'https://purl.bioontology.org/ontology'
   config.cache      = false
 end

--- a/lib/ontologies_api_client.rb
+++ b/lib/ontologies_api_client.rb
@@ -9,6 +9,7 @@ require_relative 'ontologies_api_client/base'
 require_relative 'ontologies_api_client/collection'
 require_relative 'ontologies_api_client/read_write'
 require_relative 'ontologies_api_client/analytics'
+require_relative 'ontologies_api_client/version'
 
 # Models
 curr_dir = File.expand_path("../ontologies_api_client",  __FILE__)

--- a/lib/ontologies_api_client/config.rb
+++ b/lib/ontologies_api_client/config.rb
@@ -27,6 +27,7 @@ module LinkedData
       @settings.cache                   ||= false
       @settings.enable_long_request_log ||= false
       @settings.purl_prefix             ||= "http://purl.example.org"
+      @settings.purl_host               ||= 'purl.example.org'
 
       # Remove trailing slash
       @settings.rest_url    = @settings.rest_url.chomp("/")

--- a/lib/ontologies_api_client/config.rb
+++ b/lib/ontologies_api_client/config.rb
@@ -75,7 +75,7 @@ module LinkedData
         faraday.headers = {
           'Accept' => 'application/json',
           'Authorization' => "apikey token=#{@settings.apikey}",
-          'User-Agent' => 'NCBO API Ruby Client v0.1.0'
+          'User-Agent' => "NCBO API Ruby Client v#{LinkedData::Client::VERSION}"
         }
       end
       @settings_run_connection = true

--- a/lib/ontologies_api_client/config.rb
+++ b/lib/ontologies_api_client/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 require 'faraday'
 require 'faraday/excon'
@@ -16,28 +18,30 @@ module LinkedData
 
     def config(&block)
       return if @settings_run
+
       @settings_run = true
 
       yield @settings if block_given?
 
       # Set defaults
-      @settings.rest_url                ||= "http://stagedata.bioontology.org"
-      @settings.apikey                  ||= "4ea81d74-8960-4525-810b-fa1baab576ff"
-      @settings.links_attr              ||= "links"
+      @settings.rest_url                ||= 'http://stagedata.bioontology.org'
+      @settings.apikey                  ||= '4ea81d74-8960-4525-810b-fa1baab576ff'
+      @settings.links_attr              ||= 'links'
       @settings.cache                   ||= false
       @settings.enable_long_request_log ||= false
-      @settings.purl_prefix             ||= "http://purl.example.org"
+      @settings.purl_prefix             ||= 'http://purl.example.org'
       @settings.purl_host               ||= 'purl.example.org'
 
       # Remove trailing slash
-      @settings.rest_url    = @settings.rest_url.chomp("/")
-      @settings.purl_prefix = @settings.purl_prefix.chomp("/")
+      @settings.rest_url    = @settings.rest_url.chomp('/')
+      @settings.purl_prefix = @settings.purl_prefix.chomp('/')
 
       @settings_run = true
     end
 
     def config_connection(options = {})
       return if @settings_run_connection
+
       store = options[:cache_store]
       @settings.conn = Faraday.new(@settings.rest_url) do |faraday|
         if @settings.enable_long_request_log
@@ -58,10 +62,10 @@ module LinkedData
           begin
             require_relative 'middleware/faraday-object-cache'
             faraday.use :object_cache, store: store
-            puts "=> faraday caching enabled"
+            puts '=> faraday caching enabled'
             puts "=> faraday cache store: #{store.class}"
           rescue LoadError
-            puts "=> WARNING: faraday http cache gem is not available, caching disabled"
+            puts '=> WARNING: faraday http cache gem is not available, caching disabled'
           end
         end
 
@@ -69,9 +73,9 @@ module LinkedData
         faraday.request :url_encoded
         faraday.adapter :excon
         faraday.headers = {
-          "Accept" => "application/json",
-          "Authorization" => "apikey token=#{@settings.apikey}",
-          "User-Agent" => "NCBO API Ruby Client v0.1.0"
+          'Accept' => 'application/json',
+          'Authorization' => "apikey token=#{@settings.apikey}",
+          'User-Agent' => 'NCBO API Ruby Client v0.1.0'
         }
       end
       @settings_run_connection = true

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -47,7 +47,7 @@ module LinkedData
 
         def purl
           return "" if self.links.nil?
-          return self.id if self.id.include?("purl.")
+          return self.id if self.id.include? LinkedData::Client.settings[:purl_host]
 
           ont = self.explore.ontology
           encoded_id = Addressable::URI.encode_component(self.id, Addressable::URI::CharacterClasses::UNRESERVED)

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -2,6 +2,6 @@
 
 module LinkedData
   module Client
-    VERSION = '2.2.3'
+    VERSION = '2.2.4'
   end
 end

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -2,6 +2,6 @@
 
 module LinkedData
   module Client
-    VERSION = '2.2.2'
+    VERSION = '2.2.3'
   end
 end

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module LinkedData
+  module Client
+    VERSION = '2.2.2'
+  end
+end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('spawnling', '2.1.5')
 
   gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
+  gem.add_development_dependency('minitest', '~> 5.18')
 end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('multi_json')
   gem.add_dependency('oj')
   gem.add_dependency('spawnling', '2.1.5')
+
+  gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
 end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'lib/ontologies_api_client/version'
+
 Gem::Specification.new do |gem|
   gem.authors       = ['Paul R Alexander']
   gem.email         = ['support@bioontology.org']
@@ -14,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'ontologies_api_client'
   gem.require_paths = ['lib']
-  gem.version       = '2.2.2'
+  gem.version       = LinkedData::Client::VERSION
 
   gem.add_dependency('activesupport', '6.1.7.3')
   gem.add_dependency('addressable', '~> 2.8')

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'faraday/follow_redirects'
 require_relative '../test_case'
 
 class ClassTest < LinkedData::Client::TestCase
@@ -12,5 +15,59 @@ class ClassTest < LinkedData::Client::TestCase
     assert_equal 'Activity', cls.prefLabel
     assert_equal ontology, cls.links['ontology']
     assert_true cls.hasChildren
+  end
+
+  # Test PURL generation for a class in an OWL format ontology
+  def test_purl_owl
+    cls = LinkedData::Client::Models::Class.find(
+      'http://bioontology.org/ontologies/Activity.owl#Activity',
+      'https://data.bioontology.org/ontologies/BRO'
+    )
+    refute_nil cls
+
+    res = fetch_response(cls.purl)
+    assert_equal 200, res.status
+    assert_equal 'https://bioportal.bioontology.org/ontologies/BRO'\
+                 '?p=classes&conceptid=http%3A%2F%2Fbioontology.org%2Fontologies%2FActivity.owl%23Activity',
+                 res.env[:url].to_s
+  end
+
+  # Test PURL generation for a class in a UMLS format ontology
+  def test_purl_umls
+    cls = LinkedData::Client::Models::Class.find(
+      'http://purl.bioontology.org/ontology/SNOMEDCT/64572001',
+      'https://bioportal.bioontology.org/ontologies/SNOMEDCT'
+    )
+    refute_nil cls
+
+    res = fetch_response(cls.purl)
+    assert_equal 200, res.status
+    assert_equal 'https://bioportal.bioontology.org/ontologies/SNOMEDCT?p=classes&conceptid=64572001',
+                 res.env[:url].to_s
+  end
+
+  # Test PURL generation for a class in an OBO format ontology
+  def test_purl_obo
+    cls = LinkedData::Client::Models::Class.find(
+      'http://purl.obolibrary.org/obo/DOID_4',
+      'https://bioportal.bioontology.org/ontologies/DOID'
+    )
+    refute_nil cls
+
+    res = fetch_response(cls.purl)
+    assert_equal 200, res.status
+    assert_equal 'https://bioportal.bioontology.org/ontologies/DOID'\
+                 '?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_4',
+                 res.env[:url].to_s
+  end
+
+  private
+
+  def fetch_response(url)
+    conn = Faraday.new do |f|
+      f.response :follow_redirects
+      f.adapter Faraday.default_adapter
+    end
+    conn.get(url)
   end
 end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -14,7 +14,7 @@ class ClassTest < LinkedData::Client::TestCase
     assert_equal 'http://www.w3.org/2002/07/owl#Class', cls.type
     assert_equal 'Activity', cls.prefLabel
     assert_equal ontology, cls.links['ontology']
-    assert_true cls.hasChildren
+    assert cls.hasChildren
   end
 
   # Test PURL generation for a class in an OWL format ontology

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -20,13 +20,13 @@ class CollectionTest < LinkedData::Client::TestCase
   def test_class_for_type
     media_type = 'http://data.bioontology.org/metadata/Category'
     type_cls = LinkedData::Client::Base.class_for_type(media_type)
-    assert type_cls == LinkedData::Client::Models::Category
+    assert_equal LinkedData::Client::Models::Category, type_cls
   end
 
   def test_find_by
     bro = TestOntology.find_by_acronym('BRO')
     assert bro.length >= 1
-    assert bro.any? { |o| o.acronym.eql?('BRO') }
+    assert(bro.any? { |o| o.acronym.eql?('BRO') })
 
     onts = TestOntology.find_by_hasDomain_and_doNotUpdate('https://data.bioontology.org/categories/Health', true)
     assert onts.length >= 1
@@ -42,6 +42,6 @@ class CollectionTest < LinkedData::Client::TestCase
 
   def test_find
     ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
-    assert !ont.nil?
+    refute_nil ont
   end
 end

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -1,12 +1,14 @@
-require_relative '../test_case'
+# frozen_string_literal: true
+
 require 'pry'
+require_relative '../test_case'
 
 class TestOntology < LinkedData::Client::Base
   include LinkedData::Client::Collection
   include LinkedData::Client::ReadWrite
 
-  @media_type    = "http://data.bioontology.org/metadata/Ontology"
-  @include_attrs = "all"
+  @media_type    = 'http://data.bioontology.org/metadata/Ontology'
+  @include_attrs = 'all'
 end
 
 class CollectionTest < LinkedData::Client::TestCase
@@ -16,30 +18,30 @@ class CollectionTest < LinkedData::Client::TestCase
   end
 
   def test_class_for_type
-    media_type = "http://data.bioontology.org/metadata/Category"
+    media_type = 'http://data.bioontology.org/metadata/Category'
     type_cls = LinkedData::Client::Base.class_for_type(media_type)
     assert type_cls == LinkedData::Client::Models::Category
   end
 
   def test_find_by
-    bro = TestOntology.find_by_acronym("BRO")
+    bro = TestOntology.find_by_acronym('BRO')
     assert bro.length >= 1
-    assert bro.any? {|o| o.acronym.eql?("BRO")}
+    assert bro.any? { |o| o.acronym.eql?('BRO') }
 
-    onts = TestOntology.find_by_hasDomain_and_doNotUpdate("https://data.bioontology.org/categories/Health", true)
+    onts = TestOntology.find_by_hasDomain_and_doNotUpdate('https://data.bioontology.org/categories/Health', true)
     assert onts.length >= 1
 
-    onts = TestOntology.find_by_hasDomain_and_hasDomain("https://data.bioontology.org/categories/Phenotype", "https://data.bioontology.org/categories/Human")
+    onts = TestOntology.find_by_hasDomain_and_hasDomain('https://data.bioontology.org/categories/Phenotype', 'https://data.bioontology.org/categories/Human')
     assert onts.length >= 1
   end
 
   def test_where
-    onts = TestOntology.where {|o| o.name.downcase.start_with?("c")}
+    onts = TestOntology.where { |o| o.name.downcase.start_with?('c') }
     assert onts.length >= 1
   end
 
   def test_find
-    ont = TestOntology.find("https://data.bioontology.org/ontologies/SNOMEDCT")
+    ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
     assert !ont.nil?
   end
 end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../lib/ontologies_api_client'
 require_relative '../config/config'

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,10 +1,10 @@
-require 'test-unit'
+require 'minitest/autorun'
 require_relative '../lib/ontologies_api_client'
 require_relative '../config/config'
 
 module LinkedData
   module Client
-    class TestCase < Test::Unit::TestCase
+    class TestCase < Minitest::Test
     end
   end
 end


### PR DESCRIPTION
The purpose of this pull request is to merge all of the latest code from the `ncbo/ontologies_api_ruby_client` sub-fork (versions 2.2.3 and 2.2.4).

To follow are slightly abbreviated release notes for the aforementioned release range:

### [2.2.3](https://github.com/ncbo/ontologies_api_ruby_client/releases/tag/v2.2.3)

* Modified the purl method to check class IDs for a PURL host, rather than the string 'purl'
* Made the PURL host configurable, and set a default value
* Added several unit tests for the purl method
* Configured PURL host and prefix values in config.test.rb for the purposes of unit text execution
* Added a development dependency on the [faraday-follow_redirects](https://github.com/tisba/faraday-follow-redirects) gem for testing proper PURL resolution
* Moved the gem version specifier to a module
* Fixed some RuboCop warnings
* Synced fork with the upstream repository

### [2.2.4](https://github.com/ncbo/ontologies_api_ruby_client/releases/tag/v2.2.4)

* Replace outdated test-unit with minitest

