### PR TITLE
Revert "Sync: merge releases 2.2.3 and 2.2.4 from ncbo"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '3.1']
+        ruby-version: ['2.7', '3.0']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
-# frozen_string_literal: true
-
 source 'https://rubygems.org'
 
 gemspec
 
-gem 'pry'
 gem 'rake'
 gem 'rubocop', '~> 1.43'
+gem 'pry'
+gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.2.4)
+    ontologies_api_client (2.2.2)
       activesupport (= 6.1.7.3)
       addressable (~> 2.8)
       excon
@@ -34,8 +34,6 @@ GEM
     faraday-excon (2.1.0)
       excon (>= 0.27.4)
       faraday (~> 2.0)
-    faraday-follow_redirects (0.3.0)
-      faraday (>= 1, < 3)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
@@ -51,6 +49,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
+    power_assert (2.0.3)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -74,6 +73,8 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     spawnling (2.1.5)
+    test-unit (3.5.7)
+      power_assert
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -86,12 +87,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  faraday-follow_redirects (~> 0.3)
-  minitest (~> 5.18)
   ontologies_api_client!
   pry
   rake
   rubocop (~> 1.43)
+  test-unit
 
 BUNDLED WITH
    2.3.22

--- a/config/config.test.rb
+++ b/config/config.test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # config.rb is required for testing
 # unit test makes calls to bioportal api so it needs a valid API key which can
 # be set via ENV variable UT_APIKEY
@@ -7,11 +5,9 @@ abort('UT_APIKEY env variable is not set. Canceling tests') unless ENV.include?(
 abort('UT_APIKEY env variable is set to an empty value. Canceling tests') unless ENV['UT_APIKEY'].size > 5
 
 LinkedData::Client.config do |config|
-  config.rest_url    = 'https://data.bioontology.org'
-  config.apikey      = ENV['UT_APIKEY']
-  # config.apikey    = 'xxxxx-xxxxx-xxxxxxxxxx'
-  config.links_attr  = 'links'
-  config.purl_host   = 'purl.bioontology.org'
-  config.purl_prefix = 'https://purl.bioontology.org/ontology'
-  config.cache       = false
+  config.rest_url   = 'https://data.bioontology.org'
+  config.apikey     = ENV['UT_APIKEY']
+#  config.apikey     = 'xxxxx-xxxxx-xxxxxxxxxx'
+  config.links_attr = 'links'
+  config.cache      = false
 end

--- a/lib/ontologies_api_client.rb
+++ b/lib/ontologies_api_client.rb
@@ -9,7 +9,6 @@ require_relative 'ontologies_api_client/base'
 require_relative 'ontologies_api_client/collection'
 require_relative 'ontologies_api_client/read_write'
 require_relative 'ontologies_api_client/analytics'
-require_relative 'ontologies_api_client/version'
 
 # Models
 curr_dir = File.expand_path("../ontologies_api_client",  __FILE__)

--- a/lib/ontologies_api_client/config.rb
+++ b/lib/ontologies_api_client/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'ostruct'
 require 'faraday'
 require 'faraday/excon'
@@ -18,30 +16,27 @@ module LinkedData
 
     def config(&block)
       return if @settings_run
-
       @settings_run = true
 
       yield @settings if block_given?
 
       # Set defaults
-      @settings.rest_url                ||= 'http://stagedata.bioontology.org'
-      @settings.apikey                  ||= '4ea81d74-8960-4525-810b-fa1baab576ff'
-      @settings.links_attr              ||= 'links'
+      @settings.rest_url                ||= "http://stagedata.bioontology.org"
+      @settings.apikey                  ||= "4ea81d74-8960-4525-810b-fa1baab576ff"
+      @settings.links_attr              ||= "links"
       @settings.cache                   ||= false
       @settings.enable_long_request_log ||= false
-      @settings.purl_prefix             ||= 'http://purl.example.org'
-      @settings.purl_host               ||= 'purl.example.org'
+      @settings.purl_prefix             ||= "http://purl.example.org"
 
       # Remove trailing slash
-      @settings.rest_url    = @settings.rest_url.chomp('/')
-      @settings.purl_prefix = @settings.purl_prefix.chomp('/')
+      @settings.rest_url    = @settings.rest_url.chomp("/")
+      @settings.purl_prefix = @settings.purl_prefix.chomp("/")
 
       @settings_run = true
     end
 
     def config_connection(options = {})
       return if @settings_run_connection
-
       store = options[:cache_store]
       @settings.conn = Faraday.new(@settings.rest_url) do |faraday|
         if @settings.enable_long_request_log
@@ -62,10 +57,10 @@ module LinkedData
           begin
             require_relative 'middleware/faraday-object-cache'
             faraday.use :object_cache, store: store
-            puts '=> faraday caching enabled'
+            puts "=> faraday caching enabled"
             puts "=> faraday cache store: #{store.class}"
           rescue LoadError
-            puts '=> WARNING: faraday http cache gem is not available, caching disabled'
+            puts "=> WARNING: faraday http cache gem is not available, caching disabled"
           end
         end
 
@@ -73,9 +68,9 @@ module LinkedData
         faraday.request :url_encoded
         faraday.adapter :excon
         faraday.headers = {
-          'Accept' => 'application/json',
-          'Authorization' => "apikey token=#{@settings.apikey}",
-          'User-Agent' => "NCBO API Ruby Client v#{LinkedData::Client::VERSION}"
+          "Accept" => "application/json",
+          "Authorization" => "apikey token=#{@settings.apikey}",
+          "User-Agent" => "NCBO API Ruby Client v0.1.0"
         }
       end
       @settings_run_connection = true

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -47,7 +47,7 @@ module LinkedData
 
         def purl
           return "" if self.links.nil?
-          return self.id if self.id.include? LinkedData::Client.settings[:purl_host]
+          return self.id if self.id.include?("purl.")
 
           ont = self.explore.ontology
           encoded_id = Addressable::URI.encode_component(self.id, Addressable::URI::CharacterClasses::UNRESERVED)

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module LinkedData
-  module Client
-    VERSION = '2.2.4'
-  end
-end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'lib/ontologies_api_client/version'
-
 Gem::Specification.new do |gem|
   gem.authors       = ['Paul R Alexander']
   gem.email         = ['support@bioontology.org']
@@ -16,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'ontologies_api_client'
   gem.require_paths = ['lib']
-  gem.version       = LinkedData::Client::VERSION
+  gem.version       = '2.2.2'
 
   gem.add_dependency('activesupport', '6.1.7.3')
   gem.add_dependency('addressable', '~> 2.8')
@@ -28,7 +26,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency('multi_json')
   gem.add_dependency('oj')
   gem.add_dependency('spawnling', '2.1.5')
-
-  gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
-  gem.add_development_dependency('minitest', '~> 5.18')
 end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -1,6 +1,3 @@
-# frozen_string_literal: true
-
-require 'faraday/follow_redirects'
 require_relative '../test_case'
 
 class ClassTest < LinkedData::Client::TestCase
@@ -14,60 +11,6 @@ class ClassTest < LinkedData::Client::TestCase
     assert_equal 'http://www.w3.org/2002/07/owl#Class', cls.type
     assert_equal 'Activity', cls.prefLabel
     assert_equal ontology, cls.links['ontology']
-    assert cls.hasChildren
-  end
-
-  # Test PURL generation for a class in an OWL format ontology
-  def test_purl_owl
-    cls = LinkedData::Client::Models::Class.find(
-      'http://bioontology.org/ontologies/Activity.owl#Activity',
-      'https://data.bioontology.org/ontologies/BRO'
-    )
-    refute_nil cls
-
-    res = fetch_response(cls.purl)
-    assert_equal 200, res.status
-    assert_equal 'https://bioportal.bioontology.org/ontologies/BRO'\
-                 '?p=classes&conceptid=http%3A%2F%2Fbioontology.org%2Fontologies%2FActivity.owl%23Activity',
-                 res.env[:url].to_s
-  end
-
-  # Test PURL generation for a class in a UMLS format ontology
-  def test_purl_umls
-    cls = LinkedData::Client::Models::Class.find(
-      'http://purl.bioontology.org/ontology/SNOMEDCT/64572001',
-      'https://bioportal.bioontology.org/ontologies/SNOMEDCT'
-    )
-    refute_nil cls
-
-    res = fetch_response(cls.purl)
-    assert_equal 200, res.status
-    assert_equal 'https://bioportal.bioontology.org/ontologies/SNOMEDCT?p=classes&conceptid=64572001',
-                 res.env[:url].to_s
-  end
-
-  # Test PURL generation for a class in an OBO format ontology
-  def test_purl_obo
-    cls = LinkedData::Client::Models::Class.find(
-      'http://purl.obolibrary.org/obo/DOID_4',
-      'https://bioportal.bioontology.org/ontologies/DOID'
-    )
-    refute_nil cls
-
-    res = fetch_response(cls.purl)
-    assert_equal 200, res.status
-    assert_equal 'https://bioportal.bioontology.org/ontologies/DOID'\
-                 '?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_4',
-                 res.env[:url].to_s
-  end
-
-  private
-
-  def fetch_response(url)
-    conn = Faraday.new do |f|
-      f.response :follow_redirects
-      f.adapter Faraday.default_adapter
-    end
-    conn.get(url)
+    assert_true cls.hasChildren
   end
 end

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -1,14 +1,12 @@
-# frozen_string_literal: true
-
-require 'pry'
 require_relative '../test_case'
+require 'pry'
 
 class TestOntology < LinkedData::Client::Base
   include LinkedData::Client::Collection
   include LinkedData::Client::ReadWrite
 
-  @media_type    = 'http://data.bioontology.org/metadata/Ontology'
-  @include_attrs = 'all'
+  @media_type    = "http://data.bioontology.org/metadata/Ontology"
+  @include_attrs = "all"
 end
 
 class CollectionTest < LinkedData::Client::TestCase
@@ -18,30 +16,30 @@ class CollectionTest < LinkedData::Client::TestCase
   end
 
   def test_class_for_type
-    media_type = 'http://data.bioontology.org/metadata/Category'
+    media_type = "http://data.bioontology.org/metadata/Category"
     type_cls = LinkedData::Client::Base.class_for_type(media_type)
-    assert_equal LinkedData::Client::Models::Category, type_cls
+    assert type_cls == LinkedData::Client::Models::Category
   end
 
   def test_find_by
-    bro = TestOntology.find_by_acronym('BRO')
+    bro = TestOntology.find_by_acronym("BRO")
     assert bro.length >= 1
-    assert(bro.any? { |o| o.acronym.eql?('BRO') })
+    assert bro.any? {|o| o.acronym.eql?("BRO")}
 
-    onts = TestOntology.find_by_hasDomain_and_doNotUpdate('https://data.bioontology.org/categories/Health', true)
+    onts = TestOntology.find_by_hasDomain_and_doNotUpdate("https://data.bioontology.org/categories/Health", true)
     assert onts.length >= 1
 
-    onts = TestOntology.find_by_hasDomain_and_hasDomain('https://data.bioontology.org/categories/Phenotype', 'https://data.bioontology.org/categories/Human')
+    onts = TestOntology.find_by_hasDomain_and_hasDomain("https://data.bioontology.org/categories/Phenotype", "https://data.bioontology.org/categories/Human")
     assert onts.length >= 1
   end
 
   def test_where
-    onts = TestOntology.where { |o| o.name.downcase.start_with?('c') }
+    onts = TestOntology.where {|o| o.name.downcase.start_with?("c")}
     assert onts.length >= 1
   end
 
   def test_find
-    ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
-    refute_nil ont
+    ont = TestOntology.find("https://data.bioontology.org/ontologies/SNOMEDCT")
+    assert !ont.nil?
   end
 end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,12 +1,10 @@
-# frozen_string_literal: true
-
-require 'minitest/autorun'
+require 'test-unit'
 require_relative '../lib/ontologies_api_client'
 require_relative '../config/config'
 
 module LinkedData
   module Client
-    class TestCase < Minitest::Test
+    class TestCase < Test::Unit::TestCase
     end
   end
 end


### PR DESCRIPTION
Reverts "Squash and merge" type commit of ontoportal/ontologies_api_ruby_client#3.

Regular merge commits are favored over squash and merge types.