### PR TITLE
Sync with BioPortal releases through 2.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.5.2)
+    ontologies_api_client (2.5.3)
       activesupport (= 7.2.2.1)
       addressable (~> 2.8)
       excon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ontologies_api_client (2.5.2)
-      activesupport (= 7.0.8)
+      activesupport (= 7.2.2.1)
       addressable (~> 2.8)
       excon
       faraday
@@ -15,17 +15,28 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    benchmark (0.4.0)
     bigdecimal (3.1.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    drb (2.2.1)
     excon (1.2.3)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
@@ -83,6 +94,7 @@ GEM
     rubocop-ast (1.38.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.5.0)
+    ontologies_api_client (2.5.2)
       activesupport (= 7.0.8)
       addressable (~> 2.8)
       excon

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -74,7 +74,7 @@ module LinkedData
             end
           rescue Exception => e
             params = Faraday::Utils.build_query(params)
-            path << "?" unless params.empty? || path.include?("?")
+            path += "?" unless params.empty? || path.include?("?")
             raise e, "Problem retrieving:\n#{path}#{params}\n\nError: #{e.message}\n#{e.backtrace.join("\n\t")}"
           end
 

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -2,6 +2,6 @@
 
 module LinkedData
   module Client
-    VERSION = '2.5.2'
+    VERSION = '2.5.3'
   end
 end

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -2,6 +2,6 @@
 
 module LinkedData
   module Client
-    VERSION = '2.5.0'
+    VERSION = '2.5.2'
   end
 end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = LinkedData::Client::VERSION
 
-  gem.add_dependency('activesupport', '7.0.8')
+  gem.add_dependency('activesupport', '7.2.2.1')
   gem.add_dependency('addressable', '~> 2.8')
   gem.add_dependency('excon')
   gem.add_dependency('faraday')


### PR DESCRIPTION
Requesting synchronization with BioPortal's latest minor releases: 

[2.5.1](https://github.com/ncbo/ontologies_api_ruby_client/releases/tag/v2.5.1) 
[2.5.2](https://github.com/ncbo/ontologies_api_ruby_client/releases/tag/v2.5.2) 
[2.5.3](https://github.com/ncbo/ontologies_api_ruby_client/releases/tag/v2.5.3)

Somewhat abbreviated release notes:
- Upgraded the `activesupport` gem to 7.2.2.1
- Fixed a "can't modify frozen String" error
- Fixed some RuboCop warnings
- Synchronized with the upstream repository